### PR TITLE
Fix docker file for keras-tensorflow mismatch

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -73,7 +73,7 @@ RUN apt update -y && \
 RUN ln -s $(which python3) /usr/local/bin/python
 
 RUN python -m pip install --upgrade pip && \
-    pip install tensorflow==2.5.0 tf-models-official==2.5.1 tensorflow_io==0.19.1 pyparsing==2.4.2 pycairo
+    pip install tensorflow==2.5.0 tf-models-official==2.5.1 tensorflow_io==0.19.1 keras==2.5.0rc pyparsing==2.4.2 pycairo
 
 WORKDIR /app
 


### PR DESCRIPTION
Download script doesn't work due to keras version. The issue is disclosed but the solution not pushed.

https://github.com/udacity/nd013-c1-vision-starter/issues/19